### PR TITLE
Update asset registry for cosmoshub-4

### DIFF
--- a/data/mainnet/cosmoshub-4.json
+++ b/data/mainnet/cosmoshub-4.json
@@ -141,6 +141,32 @@
         "quote": "USDT",
         "exchange": "binance"
       }
+    },
+    {
+      "coinDenom": "ONDO",
+      "coinDisplayDenom": "ONDO",
+      "coinMinimalDenom": "wei-ondo",
+      "coinIbcDenom": "ibc/622E4D024777290E25ACFB32CE149BB21EF785D78A0A3F297A7AF29A88325AED",
+      "coinDecimals": 18,
+      "coinGeckoId": "",
+      "canSwap": false,
+      "isFeeCurrency": false,
+      "isStakeCurrency": false,
+      "canWithdraw": false,
+      "canDeposit": false,
+      "canUseLiquidityMining": false,
+      "canUseLeverageLP": false,
+      "canUsePerpetual": false,
+      "canUseVaults": false,
+      "gasPriceStep": {
+        "low": 0,
+        "average": 0,
+        "high": 0
+      },
+      "cc": {
+        "quote": "",
+        "exchange": ""
+      }
     }
   ]
 }


### PR DESCRIPTION

		## Asset Registry Update

		This PR updates the asset registry for chain: **cosmoshub-4**

		### Changes:
		- Chain ID: cosmoshub-4
		- Network: mainnet
		- Added/Updated currencies: 6

		### Currency Details:
- ATOM (ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9)
- ETH (ibc/694A6B26A43A2FBECCFFEAC022DEACB39578E54207FDD32005CD976B57B98004)
- wBTC (ibc/0E293A7622DC9A6439DB60E6D234B5AF446962E27CA3AB44D0590603DFF6968E)
- PAXG (ibc/68B5E8DA9270FA00245484BB1C07AD75399AD67D54A1344F6E998B5FB69B664F)
- LINK (ibc/2A20C613F2BA256BE9FAD791B0743FBC4FE3C998EDF9234D969172F7D42FB8E7)
- ONDO (ibc/622E4D024777290E25ACFB32CE149BB21EF785D78A0A3F297A7AF29A88325AED)
